### PR TITLE
Fix Arrow Error config option type

### DIFF
--- a/src/main/java/funwayguy/epicsiegemod/core/ESM_Settings.java
+++ b/src/main/java/funwayguy/epicsiegemod/core/ESM_Settings.java
@@ -37,7 +37,7 @@ public class ESM_Settings
 	
 	//Skeleton
 	public static int SkeletonDistance;
-	public static int SkeletonAccuracy;
+	public static float SkeletonAccuracy;
 	
 	//Zombie
 	public static boolean ZombieInfectious;

--- a/src/main/java/funwayguy/epicsiegemod/handlers/ConfigHandler.java
+++ b/src/main/java/funwayguy/epicsiegemod/handlers/ConfigHandler.java
@@ -61,7 +61,7 @@ public class ConfigHandler
 		ESM_Settings.MobBombAll =			config.getBoolean("All Creeper Jockeys", CAT_CREEPER, true, "Ignores the listing and allows any mob to have a Creeper rider");
 		
 		// === SKELETON ===
-		ESM_Settings.SkeletonAccuracy =		config.getInt("Arrow Error", CAT_SKELETON, 0, 0, Integer.MAX_VALUE, "How likely Skeletons are to miss their target");
+		ESM_Settings.SkeletonAccuracy =		config.getFloat(Arrow Error", CAT_SKELETON, 0F, 0F, Float.MAX_VALUE, "How likely Skeletons are to miss their target");
 		ESM_Settings.SkeletonDistance =		config.getInt("Fire Distance", CAT_SKELETON, 64, 1, Integer.MAX_VALUE, "How far away can Skeletons shoot from");
 		ESM_Settings.WitherSkeletonRarity = config.getInt("Wither Skeleton Chance", CAT_SKELETON, 10, 0, 100, "The chance a skeleton will spawn as Wither in other dimensions");
 		


### PR DESCRIPTION
Arrow Error option was implicitly converted from int to float type when passed to EntityTippedArrow (IProjectile) shoot method.

See https://maven.thiakil.com/forge-1.12-javadoc/net/minecraft/entity/IProjectile.html#shoot-double-double-double-float-float-

>There is a random variable to the trajectory of an arrow, given by `this.rand.nextGaussian() * 0.0075 * (double)inaccuracy` for the x, y and z coordinate.

From https://minecraft.gamepedia.com/Arrow
See also https://github.com/SlimeKnights/TinkersConstruct/issues/1797